### PR TITLE
Docker fixes: use tagged images, elasticsearch and ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ When updating vocabulary definitions, you need to update triple store by running
 
 ### Running for development
 
+    git submodule init
+    git submodule update
+
+Check if `ui/docs` is writable, otherwise jekyll fails to start in the conainer
 
     mkdir -p data/consents/objects
     touch data/consents/history

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -56,6 +56,8 @@ services:
       context: ..
     expose:
       - 9200
+    ports:
+      - 9200:9200
     environment:
       - discovery.type=single-node
     #volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,11 +32,12 @@ services:
       - 3000
 
   pages:
-      image: jekyll/jekyll:stable
+      image: jekyll/jekyll:4.2.0
       command: jekyll serve --watch --incremental
       expose:
           - 4000
       volumes:
+          # must be writable
           - ../ui/docs:/srv/jekyll
 
 
@@ -55,12 +56,14 @@ services:
       context: ..
     expose:
       - 9200
+    environment:
+      - discovery.type=single-node
     #volumes:
       # TODO:
       #- ../tmp
   
   keycloak:
-    image: bitnami/keycloak:latest
+    image: bitnami/keycloak:15.0.2-debian-10-r94
     ports:
       - "9001:8080"
     depends_on:
@@ -79,7 +82,8 @@ services:
 #      - ..:/home/node/app
 
   postgresql:
-    image: postgres:latest
+    # https://github.com/docker-library/postgres/issues/1100#issuecomment-1599660628
+    image: postgres:12-bullseye
     # TODO: volumes
     environment:
       - POSTGRES_PASSWORD=password

--- a/docker/entrypoint-ui.sh
+++ b/docker/entrypoint-ui.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+echo "INSTALL"
 npm install
-npm run build:dev
-npm run server:dev
+echo "BUILD PRDO"
+npm run build:prod
+echo "SERVER PROD"
+npm run server:prod
+# does not use the right host:port
+#echo "BUILD DEV"
+#npm run build:dev
+#echo "SERVER DEV"
+#npm run server:dev

--- a/docker/httpd.Dockerfile
+++ b/docker/httpd.Dockerfile
@@ -1,6 +1,6 @@
 FROM broadinstitute/openidc-proxy AS openidc
 
-FROM httpd:latest
+FROM httpd:2.4.51-buster
 
 RUN apt-get update \
     && apt-get install -y \

--- a/docker/scala.Dockerfile
+++ b/docker/scala.Dockerfile
@@ -1,5 +1,7 @@
 FROM hseeberger/scala-sbt:8u141-jdk_2.12.3_0.13.16
 
+# use archived repo URLs
+# https://stackoverflow.com/a/76095392/2851664
 RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' \
            -e 's|security.debian.org|archive.debian.org/|g' \
            -e '/stretch-updates/d' /etc/apt/sources.list

--- a/docker/scala.Dockerfile
+++ b/docker/scala.Dockerfile
@@ -1,2 +1,7 @@
 FROM hseeberger/scala-sbt:8u141-jdk_2.12.3_0.13.16
+
+RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' \
+           -e 's|security.debian.org|archive.debian.org/|g' \
+           -e '/stretch-updates/d' /etc/apt/sources.list
+
 WORKDIR /srv/oerworldmap

--- a/docker/ui.Dockerfile
+++ b/docker/ui.Dockerfile
@@ -1,4 +1,6 @@
-FROM node:12
+FROM node:12.22.7
 WORKDIR /srv/oerworldmap-ui
 
-ENTRYPOINT [ "/srv/oerworldmap-ui/entrypoint-ui.sh" ]
+COPY docker/entrypoint-ui.sh /srv
+
+ENTRYPOINT [ "/srv/entrypoint-ui.sh" ]


### PR DESCRIPTION
use the images that were 'latest' at the time of writing the docker code the current latest images are not compatible with the code and setup

ui:
- Fix missing copying of the entrypoint script to the container
- the dev build does not pick the right configured port, but a random one, thus use the prod build and serve

elasticsearch: set the type to single node, fixing a startup error on memory